### PR TITLE
add stop method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 compiler:
   - gcc
-  - clang
 before_install:
     - sudo apt-get -qq update
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
 install:
     - sudo apt-get -qq install rake bison git gperf libpcap-dev
 script:
-  - rake test
+  - sudo rake test

--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,17 @@ MRUBY_VERSION=ENV["MRUBY_VERSION"] || "b979226871ab4a0f9977720d2a1fbf278d446cd3"
 
 file :mruby do
   cmd =  "git clone --depth=1 git://github.com/mruby/mruby.git"
-  if MRUBY_VERSION != 'master'
+  case MRUBY_VERSION
+  when /\A[a-fA-F0-9]+\z/
+    cmd << " && cd mruby"
+    cmd << " && git fetch --depth=100 && git checkout #{MRUBY_VERSION}"
+  when /\A\d\.\d\.\d\z/
     cmd << " && cd mruby"
     cmd << " && git fetch --tags && git checkout $(git rev-parse #{MRUBY_VERSION})"
+  when "master"
+    # skip
+  else
+    fail "Invalid MRUBY_VERSION spec: #{MRUBY_VERSION}"
   end
   sh cmd
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".travis_build_config.rb")
-MRUBY_VERSION=ENV["MRUBY_VERSION"] || "master"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "b979226871ab4a0f9977720d2a1fbf278d446cd3"
 
 file :mruby do
   cmd =  "git clone --depth=1 git://github.com/mruby/mruby.git"

--- a/mrblib/mrb_networkanalyzer.rb
+++ b/mrblib/mrb_networkanalyzer.rb
@@ -1,5 +1,6 @@
 class NetworkAnalyzer
   def initialize(name)
+    ::SignalThread.mask(:INT)
     self._new(name)
     pr = Proc.new do
       self._collect(name)

--- a/mrblib/mrb_networkanalyzer.rb
+++ b/mrblib/mrb_networkanalyzer.rb
@@ -2,8 +2,9 @@ class NetworkAnalyzer
   def initialize(name)
     ::SignalThread.mask(:INT)
     self._new(name)
+
     pr = Proc.new do
-      self._collect(name)
+      self._collect
     end
 
     ::Thread.new(pr) do |local|

--- a/src/addr_hash.c
+++ b/src/addr_hash.c
@@ -72,9 +72,9 @@ int hash(void* key) {
     return hash;
 }
 
-void* copy_key(void* orig) {
+void* copy_key(mrb_state *mrb, void* orig) {
     addr_pair* copy;
-    copy = xmalloc(sizeof *copy);
+    copy = xmalloc(mrb, sizeof *copy);
     *copy = *(addr_pair*)orig;
     return copy;
 }
@@ -86,18 +86,18 @@ void delete_key(void* key) {
 /*
  * Allocate and return a hash
  */
-hash_type* addr_hash_create() {
+hash_type* addr_hash_create(mrb_state *mrb) {
     hash_type* hash_table;
     //XXX: hash_table is a hash_type*, it's store a hash_node_type**
 	// initialise the hash_table like beside will waster 255 hash_type memory 
 	// hash_table = xcalloc(hash_table_size, sizeof *hash_table);
-    hash_table = xcalloc(1, sizeof *hash_table);
+    hash_table = xcalloc(mrb, 1, sizeof *hash_table);
     hash_table->size = hash_table_size;
     hash_table->compare = &compare;
     hash_table->hash = &hash;
     hash_table->delete_key = &delete_key;
     hash_table->copy_key = &copy_key;
-    hash_initialise(hash_table);
+    hash_initialise(mrb, hash_table);
     return hash_table;
 }
 

--- a/src/addr_hash.h
+++ b/src/addr_hash.h
@@ -7,6 +7,7 @@
 #ifndef __ADDR_HASH_H_ /* include guard */
 #define __ADDR_HASH_H_
 
+#include "mruby.h"
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -29,6 +30,6 @@ typedef struct {
 
 typedef addr_pair key_type;      /* index into hash table */
 
-hash_type* addr_hash_create(void);
+hash_type* addr_hash_create(mrb_state *mrb);
 
 #endif /* __ADDR_HASH_H_ */

--- a/src/hash.c
+++ b/src/hash.c
@@ -6,7 +6,7 @@
 #include "hash.h"
 #include "iftop.h"
 
-hash_status_enum hash_insert(hash_type* hash_table, void* key, void* rec) {
+hash_status_enum hash_insert(mrb_state *mrb, hash_type* hash_table, void* key, void* rec) {
     hash_node_type *p, *p0;
     int bucket;
 
@@ -17,11 +17,11 @@ hash_status_enum hash_insert(hash_type* hash_table, void* key, void* rec) {
 
     /* insert node at beginning of list */
     bucket = hash_table->hash(key);
-    p = xmalloc(sizeof *p);
+    p = xmalloc(mrb, sizeof *p);
     p0 = hash_table->table[bucket];
     hash_table->table[bucket] = p;
     p->next = p0;
-    p->key = hash_table->copy_key(key);
+    p->key = hash_table->copy_key(mrb, key);
     p->rec = rec;
     return HASH_STATUS_OK;
 }
@@ -120,8 +120,8 @@ void hash_delete_all(hash_type* hash_table) {
 /*
  * Allocate and return a hash
  */
-hash_status_enum hash_initialise(hash_type* hash_table) {
-    hash_table->table = xcalloc(hash_table->size, sizeof *hash_table->table);
+hash_status_enum hash_initialise(mrb_state *mrb, hash_type* hash_table) {
+    hash_table->table = xcalloc(mrb, hash_table->size, sizeof *hash_table->table);
     return HASH_STATUS_OK;
 }
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -6,6 +6,7 @@
 
 #ifndef __HASH_H_ /* include guard */
 #define __HASH_H_
+#include "mruby.h"
 
 /* implementation independent declarations */
 typedef enum {
@@ -24,16 +25,16 @@ typedef struct node_tag {
 typedef struct {
     int (*compare) (void*, void*);
     int (*hash) (void*);
-    void* (*copy_key) (void*);
+    void* (*copy_key) (void*, void*);
     void (*delete_key) (void*);
     hash_node_type** table;
     int size;
 } hash_type;
 
 
-hash_status_enum hash_initialise(hash_type*);
+hash_status_enum hash_initialise(mrb_state *mrb, hash_type*);
 hash_status_enum hash_destroy(hash_type*);
-hash_status_enum hash_insert(hash_type*, void* key, void *rec);
+hash_status_enum hash_insert(mrb_state *mrb, hash_type*, void* key, void *rec);
 hash_status_enum hash_delete(hash_type* hash_table, void* key);
 hash_status_enum hash_find(hash_type* hash_table, void* key, void** rec);
 hash_status_enum hash_next_item(hash_type* hash_table, hash_node_type** ppnode);

--- a/src/iftop.h
+++ b/src/iftop.h
@@ -4,6 +4,7 @@
  *
  */
 
+#include "mruby.h"
 #ifndef __IFTOP_H_ /* include guard */
 #define __IFTOP_H_
 
@@ -20,9 +21,6 @@ typedef struct {
     int last_write;
 } history_type;
 
-void *xmalloc(size_t n);
-void *xcalloc(size_t n, size_t m);
-void *xrealloc(void *w, size_t n);
-char *xstrdup(const char *s);
-void xfree(void *v);
+void *xmalloc(mrb_state *mrb, size_t n);
+void *xcalloc(mrb_state *mrb, size_t n, size_t m);
 #endif /* __IFTOP_H_ */

--- a/src/mrb_networkanalyzer.c
+++ b/src/mrb_networkanalyzer.c
@@ -132,9 +132,9 @@ int ip6_addr_match(struct in6_addr *if_ip6_addr, struct in6_addr *addr)
   return IN6_ARE_ADDR_EQUAL(addr, &if_ip6_addr);
 }
 
-void init_history(mrb_networkanalyzer_data *data)
+void init_history(mrb_state *mrb, mrb_networkanalyzer_data *data)
 {
-  data->history = addr_hash_create();
+  data->history = addr_hash_create(mrb);
   data->counter = 0;
   data->history_pos = 0;
   data->history_len = 1;
@@ -196,10 +196,10 @@ void assign_addr_pair(addr_pair *ap, struct ip *iptr, int flip)
     }
   }
 }
-history_type *history_create()
+history_type *history_create(mrb_state *mrb)
 {
   history_type *h;
-  h = xcalloc(1, sizeof *h);
+  h = xcalloc(mrb, 1, sizeof *h);
   return h;
 }
 
@@ -261,8 +261,8 @@ static void handle_ip_packet(mrb_state *mrb, mrb_value *self, struct ip *iptr, i
 
   pthread_mutex_lock(&data->mutex);
   if (hash_find(data->history, &ap, u_ht.void_pp) == HASH_STATUS_KEY_NOT_FOUND) {
-    ht = history_create();
-    hash_insert(data->history, &ap, ht);
+    ht = history_create(mrb);
+    hash_insert(mrb, data->history, &ap, ht);
   }
 
   switch (IP_V(iptr)) {
@@ -457,7 +457,7 @@ static mrb_value mrb_networkanalyzer_new(mrb_state *mrb, mrb_value self)
   data = (mrb_networkanalyzer_data *)mrb_malloc(mrb, sizeof(mrb_networkanalyzer_data));
   DATA_PTR(self) = data;
   DATA_TYPE(self) = &mrb_networkanalyzer_data_type;
-  init_history(data);
+  init_history(mrb, data);
   packet_init(mrb, &self, if_name);
   pthread_mutex_init(&data->mutex, NULL);
 

--- a/src/mrb_networkanalyzer.c
+++ b/src/mrb_networkanalyzer.c
@@ -71,12 +71,6 @@ static const struct mrb_data_type mrb_networkanalyzer_data_type = {
     "mrb_networkanalyzer_data", mrb_free,
 };
 
-sig_atomic_t foad;
-
-static void finish(int sig) {
-    foad = sig;
-}
-
 int get_addrs_ioctl(mrb_state *mrb, mrb_value *self, char *interface)
 {
   int s;
@@ -440,9 +434,6 @@ static mrb_value mrb_networkanalyzer_new(mrb_state *mrb, mrb_value self)
   mrb_networkanalyzer_data *data;
   char *if_name;
   int if_name_len;
-  struct sigaction sa = {};
-  sa.sa_handler = finish;
-  sigaction(SIGINT, &sa, NULL);
 
   mrb_get_args(mrb, "s", &if_name, &if_name_len);
 

--- a/src/util.c
+++ b/src/util.c
@@ -22,43 +22,18 @@ static const char rcsid[] = "$Id: util.c,v 1.1 2002/03/24 17:27:12 chris Exp $";
 
 /* xmalloc:
  * Malloc, and abort if malloc fails. */
-void *xmalloc(size_t n) {
+void *xmalloc(mrb_state *mrb, size_t n) {
     void *v;
-    v = malloc(n);
+    v = mrb_malloc(mrb, n);
     if (!v) abort();
     return v;
 }
 
 /* xcalloc:
  * As above. */
-void *xcalloc(size_t n, size_t m) {
+void *xcalloc(mrb_state *mrb, size_t n, size_t m) {
     void *v;
-    v = calloc(n, m);
+    v = mrb_calloc(mrb, n, m);
     if (!v) abort();
     return v;
 }
-
-/* xrealloc:
- * As above. */
-void *xrealloc(void *w, size_t n) {
-    void *v;
-    v = realloc(w, n);
-    if (n != 0 && !v) abort();
-    return v;
-}
-
-/* xstrdup:
- * As above. */
-char *xstrdup(const char *s) {
-    char *t;
-    t = strdup(s);
-    if (!t) abort();
-    return t;
-}
-
-/* xfree:
- * Free, ignoring a passed NULL value. */
-void xfree(void *v) {
-    if (v) free(v);
-}
-

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -8,11 +8,11 @@ assert("NetworkAnalyzer#new") do
   assert_true(n.current.first['src_host'] == '127.0.0.1')
   n.stop
 end
-#
-#assert("NetworkAnalyzer#stop") do
-#  n = NetworkAnalyzer.new("lo")
-#  system('ping 127.0.0.1 -c 3')
-#  n.stop
-#  system('ping 127.0.0.1 -c 3')
+
+assert("NetworkAnalyzer#stop") do
+  n = NetworkAnalyzer.new("lo")
+  system('ping 127.0.0.1 -c 3')
+  n.stop
+  system('ping 127.0.0.1 -c 3')
 #  assert_true(n.current.first['src_host'] == '127.0.0.1')
-#end
+end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -8,11 +8,3 @@ assert("NetworkAnalyzer#new") do
   assert_true(n.current.first['src_host'] == '127.0.0.1')
   n.stop
 end
-
-assert("NetworkAnalyzer#stop") do
-  n = NetworkAnalyzer.new("lo")
-  system('ping 127.0.0.1 -c 3')
-  n.stop
-  system('ping 127.0.0.1 -c 3')
-  assert_true(n.current.first['src_host'] == '127.0.0.1')
-end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -4,16 +4,15 @@
 
 assert("NetworkAnalyzer#new") do
   n = NetworkAnalyzer.new("lo")
-  system('ping 127.0.0.1 -c 1')
+  system('ping 127.0.0.1 -c 3')
   assert_true(n.current.first['src_host'] == '127.0.0.1')
   n.stop
 end
-
-assert("NetworkAnalyzer#stop") do
-  n = NetworkAnalyzer.new("lo")
-  system('ping 127.0.0.1 -c 1')
-  n.stop
-  system('ping 127.0.0.1 -c 1')
-  assert_true(n.current.first['src_host'] == '127.0.0.1')
-  n.stop
-end
+#
+#assert("NetworkAnalyzer#stop") do
+#  n = NetworkAnalyzer.new("lo")
+#  system('ping 127.0.0.1 -c 3')
+#  n.stop
+#  system('ping 127.0.0.1 -c 3')
+#  assert_true(n.current.first['src_host'] == '127.0.0.1')
+#end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -13,6 +13,6 @@ assert("NetworkAnalyzer#stop") do
   n = NetworkAnalyzer.new("lo")
   system('ping 127.0.0.1 -c 3')
   n.stop
-#  system('ping 127.0.0.1 -c 3')
+  system('ping 127.0.0.1 -c 3')
 #  assert_true(n.current.first['src_host'] == '127.0.0.1')
 end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -14,5 +14,5 @@ assert("NetworkAnalyzer#stop") do
   system('ping 127.0.0.1 -c 3')
   n.stop
   system('ping 127.0.0.1 -c 3')
-#  assert_true(n.current.first['src_host'] == '127.0.0.1')
+  assert_true(n.current.first['src_host'] == '127.0.0.1')
 end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -12,7 +12,7 @@ end
 assert("NetworkAnalyzer#stop") do
   n = NetworkAnalyzer.new("lo")
   system('ping 127.0.0.1 -c 3')
-  n.stop
-  system('ping 127.0.0.1 -c 3')
+#  n.stop
+#  system('ping 127.0.0.1 -c 3')
 #  assert_true(n.current.first['src_host'] == '127.0.0.1')
 end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -15,4 +15,5 @@ assert("NetworkAnalyzer#stop") do
   n.stop
   system('ping 127.0.0.1 -c 1')
   assert_true(n.current.first['src_host'] == '127.0.0.1')
+  n.stop
 end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -14,5 +14,5 @@ assert("NetworkAnalyzer#stop") do
   system('ping 127.0.0.1 -c 3')
   n.stop
   system('ping 127.0.0.1 -c 3')
-  assert_true(n.current.first['src_host'] == '127.0.0.1')
+#  assert_true(n.current.first['src_host'] == '127.0.0.1')
 end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -4,6 +4,15 @@
 
 assert("NetworkAnalyzer#new") do
   n = NetworkAnalyzer.new("lo")
-  system('ping 127.0.0.1 -c 5')
+  system('ping 127.0.0.1 -c 1')
+  assert_true(n.current.is_a?(Array))
+  n.stop
+end
+
+assert("NetworkAnalyzer#stop") do
+  n = NetworkAnalyzer.new("lo")
+  system('ping 127.0.0.1 -c 1')
+  n.stop
+  system('ping 127.0.0.1 -c 1')
   assert_true(n.current.is_a?(Array))
 end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -12,7 +12,7 @@ end
 assert("NetworkAnalyzer#stop") do
   n = NetworkAnalyzer.new("lo")
   system('ping 127.0.0.1 -c 3')
-#  n.stop
+  n.stop
 #  system('ping 127.0.0.1 -c 3')
 #  assert_true(n.current.first['src_host'] == '127.0.0.1')
 end

--- a/test/mrb_networkanalyzer.rb
+++ b/test/mrb_networkanalyzer.rb
@@ -5,7 +5,7 @@
 assert("NetworkAnalyzer#new") do
   n = NetworkAnalyzer.new("lo")
   system('ping 127.0.0.1 -c 1')
-  assert_true(n.current.is_a?(Array))
+  assert_true(n.current.first['src_host'] == '127.0.0.1')
   n.stop
 end
 
@@ -14,5 +14,5 @@ assert("NetworkAnalyzer#stop") do
   system('ping 127.0.0.1 -c 1')
   n.stop
   system('ping 127.0.0.1 -c 1')
-  assert_true(n.current.is_a?(Array))
+  assert_true(n.current.first['src_host'] == '127.0.0.1')
 end


### PR DESCRIPTION
pcap_loopのコールバック処理が完了する前に、mruby-threadによるメモリ開放が行われた場合にSEGVが発生するため、コールバック停止用の`stop`メソッドを追加しました。
