### PR TITLE
Use mrb_free to release memory

### DIFF
--- a/src/addr_hash.c
+++ b/src/addr_hash.c
@@ -6,6 +6,7 @@
 #include "addr_hash.h"
 #include "hash.h"
 #include "iftop.h"
+#include "mruby.h"
 
 #define hash_table_size 256
 
@@ -79,8 +80,8 @@ void* copy_key(mrb_state *mrb, void* orig) {
     return copy;
 }
 
-void delete_key(void* key) {
-    free(key);
+void delete_key(mrb_state *mrb, void* key) {
+    mrb_free(mrb, key);
 }
 
 /*

--- a/src/hash.c
+++ b/src/hash.c
@@ -26,7 +26,7 @@ hash_status_enum hash_insert(mrb_state *mrb, hash_type* hash_table, void* key, v
     return HASH_STATUS_OK;
 }
 
-hash_status_enum hash_delete(hash_type* hash_table, void* key) {
+hash_status_enum hash_delete(mrb_state *mrb, hash_type* hash_table, void* key) {
     hash_node_type *p0, *p;
     int bucket;
 
@@ -54,7 +54,7 @@ hash_status_enum hash_delete(hash_type* hash_table, void* key) {
         hash_table->table[bucket] = p->next;
     }
 
-    hash_table->delete_key(p->key);
+    hash_table->delete_key(mrb, p->key);
     free (p);
     return HASH_STATUS_OK;
 }
@@ -99,17 +99,17 @@ hash_status_enum hash_next_item(hash_type* hash_table, hash_node_type** ppnode) 
     return HASH_STATUS_OK;
 }
 
-void hash_delete_all(hash_type* hash_table) {
+void hash_delete_all(mrb_state *mrb, hash_type* hash_table) {
     int i;
     hash_node_type *n, *nn;
     for(i = 0; i < hash_table->size; i++) {
         n = hash_table->table[i];
         while(n != NULL) {
             nn = n->next;
-            hash_table->delete_key(n->key);
+            hash_table->delete_key(mrb, n->key);
 			// XXX: it's not need to delete the user's data(rec) ?
 			//hash_table->delete_key(n->rec);
-            free(n);
+            mrb_free(mrb, n);
             n = nn;
         }
         hash_table->table[i] = NULL;
@@ -125,8 +125,8 @@ hash_status_enum hash_initialise(mrb_state *mrb, hash_type* hash_table) {
     return HASH_STATUS_OK;
 }
 
-hash_status_enum hash_destroy(hash_type* hash_table) {
-    free(hash_table->table);
+hash_status_enum hash_destroy(mrb_state *mrb, hash_type* hash_table) {
+    mrb_free(mrb, hash_table->table);
     return HASH_STATUS_OK;
 }
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -26,18 +26,18 @@ typedef struct {
     int (*compare) (void*, void*);
     int (*hash) (void*);
     void* (*copy_key) (void*, void*);
-    void (*delete_key) (void*);
+    void (*delete_key) (mrb_state*, void*);
     hash_node_type** table;
     int size;
 } hash_type;
 
 
 hash_status_enum hash_initialise(mrb_state *mrb, hash_type*);
-hash_status_enum hash_destroy(hash_type*);
+hash_status_enum hash_destroy(mrb_state *mrb, hash_type*);
 hash_status_enum hash_insert(mrb_state *mrb, hash_type*, void* key, void *rec);
-hash_status_enum hash_delete(hash_type* hash_table, void* key);
+hash_status_enum hash_delete(mrb_state *mrb, hash_type* hash_table, void* key);
 hash_status_enum hash_find(hash_type* hash_table, void* key, void** rec);
 hash_status_enum hash_next_item(hash_type* hash_table, hash_node_type** ppnode);
-void hash_delete_all(hash_type* hash_table);
+void hash_delete_all(mrb_state *mrb, hash_type* hash_table);
 
 #endif /* __HASH_H_ */

--- a/src/mrb_networkanalyzer.c
+++ b/src/mrb_networkanalyzer.c
@@ -253,7 +253,6 @@ static void handle_ip_packet(mrb_state *mrb, mrb_networkanalyzer_data *data, str
     }
   }
 
-  pthread_mutex_lock(&data->mutex);
   if (hash_find(data->history, &ap, u_ht.void_pp) == HASH_STATUS_KEY_NOT_FOUND) {
     ht = history_create(mrb);
     hash_insert(mrb, data->history, &ap, ht);
@@ -287,7 +286,6 @@ static void handle_ip_packet(mrb_state *mrb, mrb_networkanalyzer_data *data, str
     data->history_totals.total_sent += len;
   }
 
-  pthread_mutex_unlock(&data->mutex);
 }
 
 void history_rotate(mrb_state *mrb, mrb_networkanalyzer_data *data)
@@ -402,7 +400,6 @@ static mrb_value mrb_networkanalyzer_current(mrb_state *mrb, mrb_value self)
   hash_node_type *n = NULL;
 
   data = (mrb_networkanalyzer_data *)DATA_PTR(self);
-  pthread_mutex_lock(&data->mutex);
 
   current = mrb_ary_new(mrb);
   while (hash_next_item(data->history, &n) == HASH_STATUS_OK) {
@@ -432,7 +429,6 @@ static mrb_value mrb_networkanalyzer_current(mrb_state *mrb, mrb_value self)
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "recv_history"), ary_recv_history);
     mrb_ary_push(mrb, current, h);
   }
-  pthread_mutex_unlock(&data->mutex);
   return current;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -25,7 +25,7 @@ static const char rcsid[] = "$Id: util.c,v 1.1 2002/03/24 17:27:12 chris Exp $";
 void *xmalloc(mrb_state *mrb, size_t n) {
     void *v;
     v = mrb_malloc(mrb, n);
-    if (!v) abort();
+    if (!v) mrb_raise(mrb, E_RUNTIME_ERROR, "memory allocate error(xmalloc)");
     return v;
 }
 
@@ -34,6 +34,6 @@ void *xmalloc(mrb_state *mrb, size_t n) {
 void *xcalloc(mrb_state *mrb, size_t n, size_t m) {
     void *v;
     v = mrb_calloc(mrb, n, m);
-    if (!v) abort();
+    if (!v) mrb_raise(mrb, E_RUNTIME_ERROR, "memory allocate error(xcalloc)");
     return v;
 }


### PR DESCRIPTION
メモリの開放をこれまでfreeで行っていたものをmrb_freeを利用するようにします。
その他 @matsumoroty の[コメント](https://github.com/pyama86/mruby-network-analyzer/pull/4#pullrequestreview-44741155)に対するFixです。